### PR TITLE
Week7 SwiftUI로 tving 구현하기

### DIFF
--- a/assignment_week2_TVING/assignment_week2_TVING/Application/SceneDelegate.swift
+++ b/assignment_week2_TVING/assignment_week2_TVING/Application/SceneDelegate.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import SwiftUI
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
@@ -19,12 +20,12 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let windowScene = (scene as? UIWindowScene) else { return }
         
+        let rootView = TvingMainView()
+        
         let window = UIWindow(windowScene: windowScene)
-        let loginVC = DailyBoxOfficeViewController()
-        let navigationController = UINavigationController(rootViewController: loginVC)
-        window.rootViewController = navigationController
-        window.makeKeyAndVisible()
+        window.rootViewController = UIHostingController(rootView: rootView)
         self.window = window
+        window.makeKeyAndVisible()
     }
     
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/assignment_week2_TVING/assignment_week2_TVING/Presentation/SwiftUI/TvingMainView.swift
+++ b/assignment_week2_TVING/assignment_week2_TVING/Presentation/SwiftUI/TvingMainView.swift
@@ -42,11 +42,11 @@ struct TvingMainView: View {
                         }) {
                             VStack(spacing: 7) {
                                 Text(tab)
-                                    .foregroundColor(selectedTab == tab ? .white : .gray)
+                                    .foregroundStyle(selectedTab == tab ? .white : .gray)
                                     .bold()
                                 Rectangle()
                                     .frame(width: 15, height: 3)
-                                    .foregroundColor(selectedTab == tab ? .white : .clear)
+                                    .foregroundStyle(selectedTab == tab ? .white : .clear)
                             }
                         }
                     }
@@ -84,12 +84,12 @@ struct TvingMainView: View {
                         
                         HStack(spacing: 0) {
                             Text("공지")
-                                .foregroundColor(.gray)
+                                .foregroundStyle(.gray)
                                 .font(.system(size: 11, weight: .medium))
                                 .padding(.leading, 17)
                             
                             Text("티빙 계정 공유 정책 추가 안내")
-                                .foregroundColor(.white)
+                                .foregroundStyle(.white)
                                 .font(.system(size: 11, weight: .medium))
                                 .padding(.leading, 8)
                             
@@ -114,7 +114,7 @@ struct TvingMainView: View {
                         
                         HStack {
                             Text("고객문의 • 이용약관 •\n사업자정보 • 인재채용")
-                                .foregroundColor(.gray)
+                                .foregroundStyle(.gray)
                                 .font(.system(size: 11, weight: .medium))
                                 .padding(.top, 13)
                                 .padding(.leading, 20)

--- a/assignment_week2_TVING/assignment_week2_TVING/Presentation/SwiftUI/TvingMainView.swift
+++ b/assignment_week2_TVING/assignment_week2_TVING/Presentation/SwiftUI/TvingMainView.swift
@@ -1,0 +1,138 @@
+//
+//  TvingMainView.swift
+//  assignment_week2_TVING
+//
+//  Created by 신혜연 on 5/30/25.
+//
+
+import SwiftUI
+
+struct TvingMainView: View {
+    
+    @State private var selectedTab: String = "홈"
+    
+    let tabs = ["홈", "드라마", "예능", "영화", "스포츠", "뉴스"]
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 0) {
+                Image("tving_title")
+                    .resizable()
+                    .frame(width: 191, height: 78)
+                
+                Spacer()
+                
+                Image("search")
+                    .resizable()
+                    .frame(width: 30, height: 30)
+                    .padding(.trailing, 10)
+                
+                Image("logo")
+                    .resizable()
+                    .frame(width: 30, height: 30)
+                    .padding(.trailing, 11)
+            }
+            
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 28) {
+                    ForEach(tabs, id: \.self) { tab in
+                        Button(action: {
+                            selectedTab = tab
+                            print("selectedTab:", selectedTab)
+                        }) {
+                            VStack(spacing: 7) {
+                                Text(tab)
+                                    .foregroundColor(selectedTab == tab ? .white : .gray)
+                                    .bold()
+                                Rectangle()
+                                    .frame(width: 15, height: 3)
+                                    .foregroundColor(selectedTab == tab ? .white : .clear)
+                            }
+                        }
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 16)
+            
+            Spacer()
+            
+            ScrollView(showsIndicators: false) {
+                if selectedTab == "홈" {
+                    VStack(spacing: 0) {
+                        Image("main_poster")
+                            .resizable()
+                            .frame(height: 400)
+                        
+                        PosterScrollView()
+                            .padding(.top, 9)
+                        
+                        LiveScrollView()
+                            .padding(.top, 18)
+                        
+                        MovieScrollView()
+                            .padding(.top, 18)
+                        
+                        BaseballScrollView()
+                            .padding(.top, 28)
+                        
+                        ChannelScrollView()
+                            .padding(.top, 28)
+                        
+                        Top5ScrollView()
+                            .padding(.top, 25)
+                        
+                        HStack(spacing: 0) {
+                            Text("공지")
+                                .foregroundColor(.gray)
+                                .font(.system(size: 11, weight: .medium))
+                                .padding(.leading, 17)
+                            
+                            Text("티빙 계정 공유 정책 추가 안내")
+                                .foregroundColor(.white)
+                                .font(.system(size: 11, weight: .medium))
+                                .padding(.leading, 8)
+                            
+                            Spacer()
+                            
+                            Button {
+                                
+                            } label: {
+                                Image(systemName: "chevron.right")
+                                    .foregroundStyle(.white)
+                                    .frame(width: 18, height: 18)
+                            }
+                            .padding(.trailing, 16)
+                        }
+                        .frame(width: 347, height: 50)
+                        .background(
+                            RoundedRectangle(cornerRadius: 5)
+                                .fill(Color.gray.opacity(0.2))
+                        )
+                        .padding(.horizontal, 14)
+                        .padding(.top, 23)
+                        
+                        HStack {
+                            Text("고객문의 • 이용약관 •\n사업자정보 • 인재채용")
+                                .foregroundColor(.gray)
+                                .font(.system(size: 11, weight: .medium))
+                                .padding(.top, 13)
+                                .padding(.leading, 20)
+                            
+                            Spacer()
+                        }
+                    }
+                    .frame(maxWidth: .infinity)
+                } else {
+                    SampleView()
+                }
+            }
+        }
+        .background(Color.black)
+    }
+}
+
+
+//#Preview {
+//    TvingMainView()
+//}

--- a/assignment_week2_TVING/assignment_week2_TVING/Presentation/SwiftUI/View/BaseballScrollView.swift
+++ b/assignment_week2_TVING/assignment_week2_TVING/Presentation/SwiftUI/View/BaseballScrollView.swift
@@ -1,0 +1,37 @@
+//
+//  BaseballScrollView.swift
+//  assignment_week2_TVING
+//
+//  Created by 신혜연 on 5/30/25.
+//
+
+import SwiftUI
+
+struct BaseballScrollView: View {
+    
+    let teams = ["team1", "team2", "team3", "team4", "team5", "team6"]
+    
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            LazyHStack(spacing: 0) {
+                ForEach(Array(teams.enumerated()), id: \.element) { index, team in
+                    ZStack {
+                        if index % 2 == 0 {
+                            Color.white
+                        }
+                        
+                        Image(team)
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 40, height: 50)
+                    }
+                    .frame(width: 80, height: 50)
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    BaseballScrollView()
+}

--- a/assignment_week2_TVING/assignment_week2_TVING/Presentation/SwiftUI/View/ChannelScrollView.swift
+++ b/assignment_week2_TVING/assignment_week2_TVING/Presentation/SwiftUI/View/ChannelScrollView.swift
@@ -1,0 +1,30 @@
+//
+//  ChannelScrollView.swift
+//  assignment_week2_TVING
+//
+//  Created by 신혜연 on 5/30/25.
+//
+
+import SwiftUI
+
+struct ChannelScrollView: View {
+    
+    let channels = ["channel1", "channel2", "channel3", "channel4"]
+    
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            LazyHStack(spacing: 7) {
+                ForEach(channels, id: \.self) { channel in
+                    Image(channel)
+                        .resizable()
+                        .frame(width: 90, height: 45)
+                }
+            }
+        }
+        .padding(.leading, 15)
+    }
+}
+
+#Preview {
+    ChannelScrollView()
+}

--- a/assignment_week2_TVING/assignment_week2_TVING/Presentation/SwiftUI/View/LiveScrollView.swift
+++ b/assignment_week2_TVING/assignment_week2_TVING/Presentation/SwiftUI/View/LiveScrollView.swift
@@ -1,0 +1,83 @@
+//
+//  LiveScrollView.swift
+//  assignment_week2_TVING
+//
+//  Created by 신혜연 on 5/30/25.
+//
+
+import SwiftUI
+
+struct LiveScrollView: View {
+    
+    let programs = ["program1", "program2", "program3", "program4"]
+    
+    let programDetails: [String: (title: String, episode: String, rating: String)] = [
+        "program1": ("별들에게 물어봐", "14화", "24.1%"),
+        "program2": ("환승연애3", "이춘섭리포트 34화", "27.2%"),
+        "program3": ("검은 태양", "8화", "16.4%"),
+        "program4": ("환혼: 빛과 그림자", "20화", "15.2%")
+    ]
+    
+    var body: some View {
+        VStack(spacing: 9) {
+            HStack(spacing: 0) {
+                Text("실시간 인기 LIVE")
+                    .foregroundColor(.white)
+                    .font(.system(size: 15))
+                    .bold()
+                    .padding(.leading, 13)
+                
+                Spacer()
+                
+                Button {
+                    
+                } label: {
+                    Text("더보기")
+                        .foregroundColor(.gray)
+                        .font(.system(size: 12))
+                        .padding(.trailing, 10)
+                }
+                
+            }
+            
+            ScrollView(.horizontal, showsIndicators: false) {
+                LazyHStack(spacing: 7) {
+                    ForEach (Array(programs.enumerated()), id: \.element) { index, program in
+                        VStack(alignment: .leading) {
+                            Image("\(program)")
+                                .resizable()
+                                .frame(width: 160, height: 80)
+                                .cornerRadius(3)
+                            
+                            HStack(alignment: .top) {
+                                Text("\(index + 1)")
+                                    .foregroundColor(.white)
+                                    .font(.system(size: 19, weight: .bold))
+                                    .rotationEffect(.degrees(10))
+                                VStack(alignment: .leading, spacing: 2)  {
+                                    if let detail = programDetails[program] {
+                                        Text(detail.title)
+                                            .foregroundColor(.white)
+                                            .font(.system(size: 10, weight: .medium))
+                                        Text(detail.episode)
+                                            .foregroundColor(.gray)
+                                            .font(.system(size: 10, weight: .regular))
+                                        Text(detail.rating)
+                                            .foregroundColor(.gray)
+                                            .font(.system(size: 10, weight: .regular))
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            .padding(.leading, 12)
+        }
+        .background(Color.black)
+    }
+}
+
+#Preview {
+    LiveScrollView()
+}

--- a/assignment_week2_TVING/assignment_week2_TVING/Presentation/SwiftUI/View/LiveScrollView.swift
+++ b/assignment_week2_TVING/assignment_week2_TVING/Presentation/SwiftUI/View/LiveScrollView.swift
@@ -22,7 +22,7 @@ struct LiveScrollView: View {
         VStack(spacing: 9) {
             HStack(spacing: 0) {
                 Text("실시간 인기 LIVE")
-                    .foregroundColor(.white)
+                    .foregroundStyle(.white)
                     .font(.system(size: 15))
                     .bold()
                     .padding(.leading, 13)
@@ -33,7 +33,7 @@ struct LiveScrollView: View {
                     
                 } label: {
                     Text("더보기")
-                        .foregroundColor(.gray)
+                        .foregroundStyle(.gray)
                         .font(.system(size: 12))
                         .padding(.trailing, 10)
                 }
@@ -51,19 +51,19 @@ struct LiveScrollView: View {
                             
                             HStack(alignment: .top) {
                                 Text("\(index + 1)")
-                                    .foregroundColor(.white)
+                                    .foregroundStyle(.white)
                                     .font(.system(size: 19, weight: .bold))
                                     .rotationEffect(.degrees(10))
                                 VStack(alignment: .leading, spacing: 2)  {
                                     if let detail = programDetails[program] {
                                         Text(detail.title)
-                                            .foregroundColor(.white)
+                                            .foregroundStyle(.white)
                                             .font(.system(size: 10, weight: .medium))
                                         Text(detail.episode)
-                                            .foregroundColor(.gray)
+                                            .foregroundStyle(.gray)
                                             .font(.system(size: 10, weight: .regular))
                                         Text(detail.rating)
-                                            .foregroundColor(.gray)
+                                            .foregroundStyle(.gray)
                                             .font(.system(size: 10, weight: .regular))
                                     }
                                 }

--- a/assignment_week2_TVING/assignment_week2_TVING/Presentation/SwiftUI/View/LiveScrollView.swift
+++ b/assignment_week2_TVING/assignment_week2_TVING/Presentation/SwiftUI/View/LiveScrollView.swift
@@ -42,7 +42,8 @@ struct LiveScrollView: View {
             
             ScrollView(.horizontal, showsIndicators: false) {
                 LazyHStack(spacing: 7) {
-                    ForEach (Array(programs.enumerated()), id: \.element) { index, program in
+                    ForEach(programs.indices, id: \.self) { index in
+                        let program = programs[index]
                         VStack(alignment: .leading) {
                             Image("\(program)")
                                 .resizable()

--- a/assignment_week2_TVING/assignment_week2_TVING/Presentation/SwiftUI/View/MovieScrollView.swift
+++ b/assignment_week2_TVING/assignment_week2_TVING/Presentation/SwiftUI/View/MovieScrollView.swift
@@ -1,0 +1,56 @@
+//
+//  MovieScrollView.swift
+//  assignment_week2_TVING
+//
+//  Created by 신혜연 on 5/30/25.
+//
+
+import SwiftUI
+
+struct MovieScrollView: View {
+    
+    let posters = ["movie1", "movie2", "movie3", "movie4"]
+    
+    var body: some View {
+        VStack(spacing: 13) {
+            HStack(spacing: 0) {
+                Text("실시간 인기 영화")
+                    .foregroundColor(.white)
+                    .font(.system(size: 15))
+                    .bold()
+                    .padding(.leading, 13)
+                
+                Spacer()
+                
+                Button {
+                    
+                } label: {
+                    Text("더보기")
+                        .foregroundColor(.gray)
+                        .font(.system(size: 12))
+                        .padding(.trailing, 10)
+                }
+                
+            }
+            
+            ScrollView(.horizontal, showsIndicators: false) {
+                LazyHStack(spacing: 8) {
+                    ForEach(posters, id: \.self) { poster in
+                        HStack(alignment: .bottom) {
+                            Image(poster)
+                                .resizable()
+                                .frame(width: 98, height: 146)
+                                .cornerRadius(3)
+                        }
+                    }
+                }
+                .padding(.leading, 15)
+            }
+        }
+        .background(Color.black)
+    }
+}
+
+#Preview {
+    MovieScrollView()
+}

--- a/assignment_week2_TVING/assignment_week2_TVING/Presentation/SwiftUI/View/MovieScrollView.swift
+++ b/assignment_week2_TVING/assignment_week2_TVING/Presentation/SwiftUI/View/MovieScrollView.swift
@@ -15,7 +15,7 @@ struct MovieScrollView: View {
         VStack(spacing: 13) {
             HStack(spacing: 0) {
                 Text("실시간 인기 영화")
-                    .foregroundColor(.white)
+                    .foregroundStyle(.white)
                     .font(.system(size: 15))
                     .bold()
                     .padding(.leading, 13)
@@ -26,7 +26,7 @@ struct MovieScrollView: View {
                     
                 } label: {
                     Text("더보기")
-                        .foregroundColor(.gray)
+                        .foregroundStyle(.gray)
                         .font(.system(size: 12))
                         .padding(.trailing, 10)
                 }

--- a/assignment_week2_TVING/assignment_week2_TVING/Presentation/SwiftUI/View/PosterScrollView.swift
+++ b/assignment_week2_TVING/assignment_week2_TVING/Presentation/SwiftUI/View/PosterScrollView.swift
@@ -1,0 +1,47 @@
+//
+//  PosterScrollView.swift
+//  assignment_week2_TVING
+//
+//  Created by 신혜연 on 5/30/25.
+//
+
+import SwiftUI
+
+struct PosterScrollView: View {
+    
+    let posters = ["movie1", "movie2", "movie3"]
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 9) {
+            Text("오늘의 티빙 TOP 20")
+                .foregroundColor(.white)
+                .font(.system(size: 15))
+                .bold()
+                .padding(.leading, 12)
+            
+            ScrollView(.horizontal, showsIndicators: false) {
+                LazyHStack(spacing: 16) {
+                    ForEach(Array(posters.enumerated()), id: \.element) { index, poster in
+                        HStack(alignment: .bottom) {
+                            Text("\(index + 1)")
+                                .foregroundColor(.white)
+                                .font(.system(size: 50, weight: .bold))
+                                .rotationEffect(.degrees(10))
+                            
+                            Image(poster)
+                                .resizable()
+                                .frame(width: 98, height: 146)
+                                .cornerRadius(3)
+                        }
+                    }
+                }
+                .padding(.leading, 16)
+            }
+        }
+        .background(Color.black)
+    }
+}
+
+#Preview {
+    PosterScrollView()
+}

--- a/assignment_week2_TVING/assignment_week2_TVING/Presentation/SwiftUI/View/PosterScrollView.swift
+++ b/assignment_week2_TVING/assignment_week2_TVING/Presentation/SwiftUI/View/PosterScrollView.swift
@@ -14,7 +14,7 @@ struct PosterScrollView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 9) {
             Text("오늘의 티빙 TOP 20")
-                .foregroundColor(.white)
+                .foregroundStyle(.white)
                 .font(.system(size: 15))
                 .bold()
                 .padding(.leading, 12)
@@ -24,7 +24,7 @@ struct PosterScrollView: View {
                     ForEach(Array(posters.enumerated()), id: \.element) { index, poster in
                         HStack(alignment: .bottom) {
                             Text("\(index + 1)")
-                                .foregroundColor(.white)
+                                .foregroundStyle(.white)
                                 .font(.system(size: 50, weight: .bold))
                                 .rotationEffect(.degrees(10))
                             

--- a/assignment_week2_TVING/assignment_week2_TVING/Presentation/SwiftUI/View/SampleView.swift
+++ b/assignment_week2_TVING/assignment_week2_TVING/Presentation/SwiftUI/View/SampleView.swift
@@ -1,0 +1,24 @@
+//
+//  SampleView.swift
+//  assignment_week2_TVING
+//
+//  Created by 신혜연 on 5/30/25.
+//
+
+import SwiftUI
+
+struct SampleView: View {
+    var body: some View {
+        ZStack {
+            Color.black
+                .ignoresSafeArea(edges: .all)
+            
+            Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+                .foregroundStyle(.white)
+        }
+    }
+}
+
+#Preview {
+    SampleView()
+}

--- a/assignment_week2_TVING/assignment_week2_TVING/Presentation/SwiftUI/View/Top5ScrollView.swift
+++ b/assignment_week2_TVING/assignment_week2_TVING/Presentation/SwiftUI/View/Top5ScrollView.swift
@@ -1,0 +1,42 @@
+//
+//  Top5ScrollView.swift
+//  assignment_week2_TVING
+//
+//  Created by 신혜연 on 5/30/25.
+//
+
+import SwiftUI
+
+struct Top5ScrollView: View {
+    
+    let programs = ["program1", "program2", "program3", "program4"]
+    
+    var body: some View {
+        VStack(spacing: 13) {
+            HStack(spacing: 0) {
+                Text("실시간 인기 LIVE")
+                    .foregroundColor(.white)
+                    .font(.system(size: 15, weight: .bold))
+
+                Spacer()
+            }
+            .padding(.leading, 15)
+            
+            ScrollView(.horizontal, showsIndicators: false) {
+                LazyHStack(spacing: 8) {
+                    ForEach (programs, id: \.self) { program in
+                        Image("\(program)")
+                            .resizable()
+                            .frame(width: 160, height: 90)
+                            .cornerRadius(3)
+                    }
+                }
+            }
+            .padding(.leading, 16)
+        }
+    }
+}
+
+#Preview {
+    Top5ScrollView()
+}

--- a/assignment_week2_TVING/assignment_week2_TVING/Presentation/SwiftUI/View/Top5ScrollView.swift
+++ b/assignment_week2_TVING/assignment_week2_TVING/Presentation/SwiftUI/View/Top5ScrollView.swift
@@ -15,7 +15,7 @@ struct Top5ScrollView: View {
         VStack(spacing: 13) {
             HStack(spacing: 0) {
                 Text("실시간 인기 LIVE")
-                    .foregroundColor(.white)
+                    .foregroundStyle(.white)
                     .font(.system(size: 15, weight: .bold))
 
                 Spacer()


### PR DESCRIPTION
## 📟 연결된 이슈
closed #7 

<br>

## 👷 작업한 내용

- SceneDeLegate SwiftUI에 맞춰 수정하였습니다.
- TvingMainview 안에 탭 카테고리 구현 및 다른 ScrollView들을 배치하였습니다.
- PosterScrollView 구현하였습니다.
- LiveScrollView 구현하였습니다. 
- MovieScrollview 구현하였습니다.
- BaseballScrollview 구현하였습니다.
- ChannelScrollview 구현하였습니다.
- Top5ScrollView 구현하였습니다.
- 홈 외의 탭 선택 시 보여줄 SampLeview 추가하였습니다.

<br>

## 📸 스크린샷
<img src = "https://github.com/user-attachments/assets/39bfa41d-0e19-41b3-9dab-e37ad77cd41d" width ="250">

<br><br>

## ✏️ 끄적슨 .. . .. 
UIKit으로 뷰를 그렸을 때보다 SwiftUI로 그렸을 때의 속도와 파일 개수가 증명해주는 효율성을 실감하였습니다 ... 
스유좋아요스유좋아요너무좋아요효자프워로임명합니다

그리고 생선님들 하나 궁금한 점이 있었는데요 🤔 
스유에서는 유킷에서 사용한 MVC 패턴보다는 MVVM을 거의 사용하는 것으로 알고 있는데, 
그렇다면 메인뷰와 서브뷰의 뎁스 차이를 어떤 방식으로 표현하나요 -?
 다 -머시기머시기View로 끝나니까 Main이라는 이름을 붙여도 뭔가 아쉬운 마음입니다.
이것은 뷰들의 향연슨 이게 맞나요 ...? 허허

```
📁 SwiftUI  
└── 📁 View  
    ├── 📄 TvingMainView.swift         # 메인 뷰 - 아래 여러 뷰들을 포함하는 상위 뷰
    ├── 📄 PosterScrollView.swift      # 포스터 목록 뷰
    ├── 📄 LiveScrollView.swift        # 라이브 콘텐츠 뷰
    ├── 📄 MovieScrollView.swift       # 영화 콘텐츠 뷰
    ├── 📄 BaseballScrollView.swift    # 야구 중계 뷰
    ├── 📄 ChannelScrollView.swift     # 채널 뷰
    ├── 📄 Top5ScrollView.swift        # TOP5 콘텐츠 뷰
    └── 📄 SampleView.swift            # 타 탭에서 보여줄 샘플 뷰
```

하 ... 이상 화요일까지인 과제를 금요일로 알고 해버린 사람이었슨니다 ... 어쩐지 나밖에 과제를 안 냇드라 ㅋ